### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for glo-grafana-globalhub-1-4

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -39,7 +39,8 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 LABEL com.redhat.component="multicluster-global-hub-grafana"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-grafana"
+LABEL name="multicluster-globalhub/multicluster-globalhub-grafana-rhel9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.4::el9"
 LABEL version="release-1.4"
 LABEL summary="Grafana is an open-source, general purpose dashboard and graph composer"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
