### PR TITLE
Add slack notification configuration for glo-grafana release 1.6

### DIFF
--- a/.tekton/glo-grafana-globalhub-1-6-push.yaml
+++ b/.tekton/glo-grafana-globalhub-1-6-push.yaml
@@ -53,7 +53,7 @@ spec:
   - name: slack-member-id
     # Will mention the user in the slack message when the pipeline run failed; this is not required.
     # Please make sure replace the value with component owner's slack member id.
-    value: "S09JCE3DF9N" 
+    value: "S09JCE3DF9N"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/glo-grafana-globalhub-1-6-push.yaml
+++ b/.tekton/glo-grafana-globalhub-1-6-push.yaml
@@ -41,6 +41,19 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[ {"type": "gomod", "path": "."} ]'
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-1-6"
+  - name: slack-webhook-url-secret-name
+    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-member-id
+    # Will mention the user in the slack message when the pipeline run failed; this is not required.
+    # Please make sure replace the value with component owner's slack member id.
+    value: "S09JCE3DF9N" 
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Add slack notification configuration to glo-grafana Konflux pipeline for release 1.6
- Enable build failure notifications via Slack webhook integration
- Configure proper webhook secret references and user notification settings

## Test plan
- [ ] Verify pipeline runs successfully with slack notification parameters
- [ ] Confirm slack notifications are sent on pipeline failures
- [ ] Test webhook configuration is properly referenced

🤖 Generated with [Claude Code](https://claude.ai/code)