### PR TITLE
Update CPE label and component name for release 1.6

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -36,11 +36,12 @@ RUN cp ./bin/linux-$(go env GOARCH)/grafana* /usr/bin/
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster-global-hub-grafana"
+LABEL com.redhat.component="multicluster-globalhub-grafana"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-grafana"
-LABEL version="release-1.5"
+LABEL name="multicluster-globalhub/multicluster-globalhub-grafana"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.6::el9"
+LABEL version="release-1.6"
 LABEL summary="Grafana is an open-source, general purpose dashboard and graph composer"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
- Add CPE label: `cpe:/a:redhat:multicluster_globalhub:1.6::el9`
- Update component name from `multicluster-global-hub-grafana` to `multicluster-globalhub-grafana`
- Update version from `release-1.5` to `release-1.6`
- Update name from `multicluster-global-hub` to `multicluster-globalhub`

## Test plan
- Verify Containerfile.konflux has correct CPE label and component name
- Verify build passes in Konflux

Generated with [Claude Code](https://claude.com/claude-code)