### PR TITLE
Fix urllib3 CVEs by switching to ubi-minimal base image

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -33,7 +33,7 @@ RUN make build-go
 RUN cp ./bin/linux-$(go env GOARCH)/grafana* /usr/bin/
 
 # Final container
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-global-hub-grafana"


### PR DESCRIPTION
## Summary

Switch base image from `ubi9/ubi:latest` to `ubi9/ubi-minimal:latest` to remove urllib3 and fix the following CVEs:

- **CVE-2026-21441**: urllib3 decompression-bomb safeguard bypass
- **CVE-2025-66471**: urllib3 high compression data vulnerability
- **CVE-2025-66418**: urllib3 infinite decompression chain

## Related Jira Issues

- [ACM-28391](https://issues.redhat.com/browse/ACM-28391): CVE-2026-21441
- [ACM-28185](https://issues.redhat.com/browse/ACM-28185): CVE-2025-66471
- [ACM-27667](https://issues.redhat.com/browse/ACM-27667): CVE-2025-66418

## Changes

- `Containerfile.konflux`: Changed base image from `ubi9/ubi:latest` to `ubi9/ubi-minimal:latest`

## Rationale

The `ubi-minimal` base image does not include Python or urllib3, eliminating the vulnerable dependency entirely. This is the same approach used in `release-1.7`.

## Test Plan

- [ ] Konflux image build passes
- [ ] Container runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)