### PR TITLE
Update release-1.8 grafana configuration

### DIFF
--- a/.tekton/glo-grafana-globalhub-1-8-pull-request.yaml
+++ b/.tekton/glo-grafana-globalhub-1-8-pull-request.yaml
@@ -2,20 +2,20 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: "konflux-patch.sh"
     build.appstudio.openshift.io/repo: https://github.com/stolostron/glo-grafana?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.8"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-globalhub-1-7
-    appstudio.openshift.io/component: glo-grafana-globalhub-1-7
+    appstudio.openshift.io/application: release-globalhub-1-8
+    appstudio.openshift.io/component: glo-grafana-globalhub-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: glo-grafana-globalhub-1-7-on-push
+  name: glo-grafana-globalhub-1-8-on-pull-request
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -24,7 +24,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-7:{{revision}}
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-8:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
@@ -41,19 +43,6 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[ {"type": "gomod", "path": "."}, {"type": "gomod", "path": "pkg/codegen"}, {"type": "gomod", "path": "pkg/plugins/codegen"} ]'
-  - name: send-slack-notification
-    value: "true"
-  - name: konflux-application-name
-    value: "release-globalhub-1-7"
-  - name: slack-webhook-url-secret-name
-    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
-    value: "slack-notify-webhook"
-  - name: slack-webhook-url-secret-key
-    value: "slack-webhook-url"
-  - name: slack-group-id
-    # Will mention the user in the slack message when the pipeline run failed; this is not required.
-    # Please make sure replace the value with component owner's slack member id.
-    value: "S09JCE3DF9N"
   taskRunSpecs:
     - pipelineTaskName: build-source-image
       computeResources:
@@ -69,7 +58,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-base.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-glo-grafana-globalhub-1-7
+    serviceAccountName: build-pipeline-glo-grafana-globalhub-1-8
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/glo-grafana-globalhub-1-8-push.yaml
+++ b/.tekton/glo-grafana-globalhub-1-8-push.yaml
@@ -2,20 +2,20 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: "konflux-patch.sh"
     build.appstudio.openshift.io/repo: https://github.com/stolostron/glo-grafana?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.8"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-globalhub-1-7
-    appstudio.openshift.io/component: glo-grafana-globalhub-1-7
+    appstudio.openshift.io/application: release-globalhub-1-8
+    appstudio.openshift.io/component: glo-grafana-globalhub-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: glo-grafana-globalhub-1-7-on-pull-request
+  name: glo-grafana-globalhub-1-8-on-push
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -24,9 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-7:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-8:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -43,6 +41,19 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[ {"type": "gomod", "path": "."}, {"type": "gomod", "path": "pkg/codegen"}, {"type": "gomod", "path": "pkg/plugins/codegen"} ]'
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-1-8"
+  - name: slack-webhook-url-secret-name
+    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-group-id
+    # Will mention the user in the slack message when the pipeline run failed; this is not required.
+    # Please make sure replace the value with component owner's slack member id.
+    value: "S09JCE3DF9N"
   taskRunSpecs:
     - pipelineTaskName: build-source-image
       computeResources:
@@ -58,7 +69,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-base.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-glo-grafana-globalhub-1-7
+    serviceAccountName: build-pipeline-glo-grafana-globalhub-1-8
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Update release-1.8 grafana configuration

## Changes

- Rename and update pull-request pipeline for `globalhub-1-8`
- Rename and update push pipeline for `globalhub-1-8`
- Update branch references to `release-1.8`

## Version Mapping

- **ACM**: release-2.17
- **Global Hub**: v1.8.0
- **Grafana branch**: release-1.8
- **Previous release**: release-1.7