### PR TITLE
fix: add GH_TOKEN to pr-external-labelling workflow

### DIFF
--- a/.github/workflows/pr-external-labelling.yml
+++ b/.github/workflows/pr-external-labelling.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Add the 'pr/external' label
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Adding 'pr/external' label to the PR"
           gh pr edit "$PR_NUMBER" --add-label pr/external


### PR DESCRIPTION
The gh CLI requires GH_TOKEN to be set as an environment variable to authenticate when adding labels to PRs. Without it, the workflow fails for all external contributor PRs.

Made-with: Cursor