### PR TITLE
fix: add pr-external-labelling workflow to release-1.4

### DIFF
--- a/.github/workflows/pr-external-labelling.yml
+++ b/.github/workflows/pr-external-labelling.yml
@@ -1,0 +1,26 @@
+name: External PR labelling
+
+on:
+  # We need "write" permissions on the PR to be able to add a label.
+  pull_request_target: # zizmor: ignore[dangerous-triggers] We need this to have labelling permissions. There are no user inputs here, so we should be fine.
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  label-if-external:
+    name: Add 'pr/external' label if the PR is external
+    if: github.event.pull_request.author_association != 'MEMBER' && github.event.pull_request.author_association != 'OWNER'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to write the label
+
+    steps:
+      - name: Add the 'pr/external' label
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Adding 'pr/external' label to the PR"
+          gh pr edit "$PR_NUMBER" --add-label pr/external


### PR DESCRIPTION
The `pr-external-labelling` workflow is missing from `release-1.4`. Without it, the CI job "Add 'pr/external' label if the PR is external" fails for all PRs targeting this branch.

This is a port of the same workflow that was fixed in `release-1.8` via [PR #212](https://github.com/stolostron/glo-grafana/pull/212).

Made-with: Cursor

Made with [Cursor](https://cursor.com)