### PR TITLE
fix: update name/cpe labels in Containerfile.konflux [multicluster-globalhub-1.3]

### DIFF
--- a/.github/workflows/pr-external-labelling.yml
+++ b/.github/workflows/pr-external-labelling.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           echo "Adding 'pr/external' label to the PR"
           gh pr edit "$PR_NUMBER" --add-label pr/external

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -36,10 +36,11 @@ RUN cp ./bin/linux-$(go env GOARCH)/grafana* /usr/bin/
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster-global-hub-grafana"
+LABEL com.redhat.component="multicluster-globalhub-grafana"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.3::el9"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-grafana"
+LABEL name="multicluster-globalhub/multicluster-globalhub-grafana-rhel9"
 LABEL version="release-1.4"
 LABEL summary="Grafana is an open-source, general purpose dashboard and graph composer"
 LABEL io.openshift.expose-services=""

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,10 @@
 approvers:
 - clyang82
 - morvencao
+- bjoydeep
+- birsanv
 
 reviewers:
 - ldpliu
+- bjoydeep
+- birsanv


### PR DESCRIPTION
## Summary

Backport of KONFLUX-6210 label fixes from `release-1.5` to `release-1.3`.

The Konflux release pipeline `step-enforce-name-label` check is failing for `glo-grafana-globalhub-1-3` because the container image `name` label uses an older format that no longer matches what Konflux derives from the `rh-registry-repo` URL.

**Error:**
```
Error: Component 'glo-grafana-globalhub-1-3' name label ('multicluster-global-hub/multicluster-global-hub-grafana')
       does not match expected name ('multicluster-globalhub/multicluster-globalhub-grafana-rhel9')
```

**Changes to `Containerfile.konflux`:**
| Label | Before | After |
|-------|--------|-------|
| `name` | `multicluster-global-hub/multicluster-global-hub-grafana` | `multicluster-globalhub/multicluster-globalhub-grafana-rhel9` |
| `com.redhat.component` | `multicluster-global-hub-grafana` | `multicluster-globalhub-grafana` |
| `cpe` | _(missing)_ | `cpe:/a:redhat:multicluster_globalhub:1.3::el9` |

Same fix was applied to `release-1.5+` via KONFLUX-6210 but was never backported to `release-1.3`.

Made with [Cursor](https://cursor.com)