### PR TITLE
Security: Fix ACM-32784 - CVE-2026-32282 Go os/root: Root.Chmod symlink escape [multicluster-globalhub-1.7]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.25.7
+go 1.25.9
 
 // Override containerd to fix CVE-2024-25621 (local privilege escalation)
 replace github.com/containerd/containerd => github.com/containerd/containerd v1.7.29

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.7
+go 1.25.9
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.


### PR DESCRIPTION
## Summary

Fixes [ACM-32784](https://redhat.atlassian.net/browse/ACM-32784) — CVE-2026-32282 (CVSS 6.4 MEDIUM)

### Root Cause

`os.Root.Chmod` on Linux has a TOCTOU race: if the target is replaced with a symlink between the pre-check and the `fchmodat` call, the chmod follows the symlink outside the root. The Linux kernel silently ignores `AT_SYMLINK_NOFOLLOW` in `fchmodat`. Fixed in Go 1.25.9 (GO-2026-4864).

### Fix

Bump Go toolchain from `1.25.7` → `1.25.9` in both `go.mod` and `go.work`.

```
go.mod:  go 1.25.7 → go 1.25.9
go.work: go 1.25.7 → go 1.25.9
```

### References
- https://pkg.go.dev/vuln/GO-2026-4864
- https://go.dev/issue/78293

Made with [Cursor](https://cursor.com)

[ACM-32784]: https://redhat.atlassian.net/browse/ACM-32784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ