### PR TITLE
chore: add birsanv and bjoydeep to OWNERS on release-1.7

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,8 @@ approvers:
 - thibaultmg
 - moadz
 - jacobbaungard
+- bjoydeep
+- birsanv
 reviewers:
 - subbarao-meduri
 - saswatamcode
@@ -14,3 +16,5 @@ reviewers:
 - thibaultmg
 - moadz
 - jacobbaungard
+- bjoydeep
+- birsanv


### PR DESCRIPTION
birsanv and bjoydeep are approvers on all prior branches (1.3–1.6) but were missing from the release-1.7 OWNERS file after the upstream Grafana fork updated the file with a new set of owners. Adding them back so security PRs on this branch can be approved by the Global Hub team.

Made with [Cursor](https://cursor.com)