### PR TITLE
fix: pin ubi-minimal to 9.6 to pass FIPS check

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -44,7 +44,7 @@ RUN go run build.go -cgo-enabled -build-tags=strictfipsruntime build
 RUN cp ./bin/linux-$(go env GOARCH)/grafana* /usr/bin/
 
 # Final container
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-grafana-rhel9"


### PR DESCRIPTION
## Problem

The `fbc-fips-check-oci-ta` FIPS scan task in the catalog pipeline fails with:

```
multicluster-globalhub-grafana-rhel9, /etc/redhat-release, operating system is not FIPS certified
```

**Root cause:** The task uses a pinned version of `check-payload` (`sha256:247616a7...`) that does not include RHEL 9.8 in its approved FIPS-certified OS list. Since 1.7 was released in November 2025, `ubi9/ubi-minimal:latest` moved from **RHEL 9.6 → RHEL 9.8**, causing the check to fail.

- 1.7 grafana build (Nov 2025): `ubi-minimal:latest` = RHEL 9.6 → ✅ passed
- 1.8 grafana build (May 2026): `ubi-minimal:latest` = RHEL 9.8 → ❌ fails

## Fix

Pin the final stage base image to `ubi-minimal:9.6`, which the current pinned `check-payload` version recognizes as FIPS-certified.

## Permanent Fix (tracked separately)

`stolostron/konflux-build-catalog` needs to update `pipelines/common-fbc.yaml` to use the newer task:
```
# From:
task-fbc-fips-check-oci-ta:0.1@sha256:247616a7e353ac77f2433989802cd3854c0b3b674386e160cae80c075a95f7db
# To:
task-fbc-fips-check-oci-ta:0.1@sha256:23c6e304a68d4b103007916aa5af7aee7898c1737d6879a64dc984138cbd22b6
```
Once that is done, this pin can be reverted to `:latest`.

Made with [Cursor](https://cursor.com)