### PR TITLE
fix(deps): update tempo/grafana logql deps on release-1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "@grafana/flamegraph": "workspace:*",
     "@grafana/google-sdk": "0.1.2",
     "@grafana/lezer-logql": "0.2.4",
-    "@grafana/monaco-logql": "^0.0.7",
+    "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -9,7 +9,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "1.7.11",
     "@grafana/lezer-logql": "0.2.4",
-    "@grafana/lezer-traceql": "0.0.17",
+    "@grafana/lezer-traceql": "0.0.25",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/runtime": "workspace:*",

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -10,7 +10,7 @@
     "@grafana/experimental": "1.7.11",
     "@grafana/lezer-logql": "0.2.4",
     "@grafana/lezer-traceql": "0.0.25",
-    "@grafana/monaco-logql": "^0.0.7",
+    "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,7 +2893,7 @@ __metadata:
     "@grafana/experimental": "npm:1.7.11"
     "@grafana/lezer-logql": "npm:0.2.4"
     "@grafana/lezer-traceql": "npm:0.0.25"
-    "@grafana/monaco-logql": "npm:^0.0.7"
+    "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "npm:11.1.0"
     "@grafana/runtime": "workspace:*"
@@ -3253,12 +3253,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/monaco-logql@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "@grafana/monaco-logql@npm:0.0.7"
+"@grafana/monaco-logql@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "@grafana/monaco-logql@npm:0.0.8"
   peerDependencies:
     monaco-editor: ^0.32.1
-  checksum: 10/a900e24912476997f30349e6ee24041c0cffebf6706d8b9203eb952f12c768fc0fd6be8d7abe86d02019a0d8f26b83d15ffd0fb09d97047307e2ba5b4ba43a1b
+  checksum: 10/30443df2bab511e5b385cb8cd5b8ae54b09f794cd3e2b1ad9cdcd58c46d3384b90d3d738c36e63702c17d914d58ad765c93d89d1398e050fa7c9ab68d940386d
   languageName: node
   linkType: hard
 
@@ -16996,7 +16996,7 @@ __metadata:
     "@grafana/flamegraph": "workspace:*"
     "@grafana/google-sdk": "npm:0.1.2"
     "@grafana/lezer-logql": "npm:0.2.4"
-    "@grafana/monaco-logql": "npm:^0.0.7"
+    "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:1.3.2"
     "@grafana/prometheus": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,7 +2892,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/experimental": "npm:1.7.11"
     "@grafana/lezer-logql": "npm:0.2.4"
-    "@grafana/lezer-traceql": "npm:0.0.17"
+    "@grafana/lezer-traceql": "npm:0.0.25"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "npm:11.1.0"
@@ -3244,12 +3244,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.17":
-  version: 0.0.17
-  resolution: "@grafana/lezer-traceql@npm:0.0.17"
+"@grafana/lezer-traceql@npm:0.0.25":
+  version: 0.0.25
+  resolution: "@grafana/lezer-traceql@npm:0.0.25"
   peerDependencies:
-    "@lezer/lr": ^1.3.0
-  checksum: 10/f9b32989ab5bab1f6407b1c83c4fd3169d589cd83d2abe95bcf68dca1ce1c512b923a0087dd010f528a202f47d102ae6dec81385f6a506632f23ece1e471a3df
+    "@lezer/lr": ^1.4.2
+  checksum: 10/f33760b5d00b4b1ddd715be3e9797f51e96c15d45adf53e94112ae13caa0adf64c89c07804103d716f74ab7941d0c53ff1a97abe72948f4ecce1710d8388e121
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Replacement for stale MintMaker PRs #200 and #201.

- `@grafana/lezer-traceql` 0.0.17 → 0.0.25 (tempo plugin)
- `@grafana/monaco-logql` ^0.0.7 → ^0.0.8 (root + tempo plugin)
- Rebases on current `release-1.6`

## Why #200 / #201 failed
- Branches were behind current `release-1.6`; Konflux `fetch-product-metadata` failed on old pipeline snapshots
- `pr/external` labelling workflow missing on stale base

## Test plan
- [x] `/ok-to-test`
- [ ] Konflux `glo-grafana-globalhub-1-6-on-pull-request` passes

Supersedes #200, #201.