### PR TITLE
chore(deps): update dependency @types/jest to v29.5.14 (release-1.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/google.analytics": "^0.0.46",
     "@types/gtag.js": "^0.0.20",
     "@types/history": "4.7.11",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/jquery": "3.5.34",
     "@types/js-yaml": "^4.0.5",
     "@types/jsurl": "^1.2.28",

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -89,7 +89,7 @@
     "@types/d3": "7.4.3",
     "@types/debounce-promise": "3.1.9",
     "@types/eslint": "8.56.12",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/jquery": "3.5.34",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -56,7 +56,7 @@
     "@testing-library/user-event": "14.5.2",
     "@types/angular": "1.8.9",
     "@types/history": "4.7.11",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.2.25",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -138,7 +138,7 @@
     "@types/d3": "7.4.3",
     "@types/hoist-non-react-statics": "3.3.7",
     "@types/is-hotkey": "0.1.10",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/jquery": "3.5.34",
     "@types/lodash": "4.17.4",
     "@types/mock-raf": "1.0.6",

--- a/public/app/plugins/datasource/azuremonitor/package.json
+++ b/public/app/plugins/datasource/azuremonitor/package.json
@@ -30,7 +30,7 @@
     "@testing-library/dom": "10.0.0",
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/prismjs": "1.26.4",

--- a/public/app/plugins/datasource/cloud-monitoring/package.json
+++ b/public/app/plugins/datasource/cloud-monitoring/package.json
@@ -32,7 +32,7 @@
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
     "@types/debounce-promise": "3.1.9",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/prismjs": "1.26.4",

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -20,7 +20,7 @@
     "@grafana/plugin-configs": "11.1.0",
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/react": "18.3.3",

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
@@ -25,7 +25,7 @@
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/prismjs": "1.26.4",

--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -28,7 +28,7 @@
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
     "@types/d3-random": "^3.0.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/react": "18.3.3",

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -28,7 +28,7 @@
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/logfmt": "^1.2.3",
     "@types/node": "20.14.2",

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -20,7 +20,7 @@
     "@grafana/plugin-configs": "11.1.0",
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/react": "18.3.3",

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -44,7 +44,7 @@
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "15.0.2",
     "@testing-library/user-event": "14.5.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/prismjs": "1.26.4",

--- a/public/app/plugins/datasource/zipkin/package.json
+++ b/public/app/plugins/datasource/zipkin/package.json
@@ -23,7 +23,7 @@
     "@grafana/plugin-configs": "workspace:*",
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "15.0.2",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.4",
     "@types/node": "20.14.2",
     "@types/react": "18.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,7 +2590,7 @@ __metadata:
     "@testing-library/dom": "npm:10.0.0"
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/prismjs": "npm:1.26.4"
@@ -2632,7 +2632,7 @@ __metadata:
     "@grafana/ui": "npm:11.1.0"
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/react": "npm:18.3.3"
@@ -2663,7 +2663,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:6.4.2"
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/prismjs": "npm:1.26.4"
@@ -2706,7 +2706,7 @@ __metadata:
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
     "@types/d3-random": "npm:^3.0.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/react": "npm:18.3.3"
@@ -2747,7 +2747,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:6.4.2"
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/logfmt": "npm:^1.2.3"
     "@types/node": "npm:20.14.2"
@@ -2787,7 +2787,7 @@ __metadata:
     "@grafana/ui": "npm:11.1.0"
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/react": "npm:18.3.3"
@@ -2853,7 +2853,7 @@ __metadata:
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
     "@types/debounce-promise": "npm:3.1.9"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/prismjs": "npm:1.26.4"
@@ -2909,7 +2909,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:6.4.2"
     "@testing-library/react": "npm:15.0.2"
     "@testing-library/user-event": "npm:14.5.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/prismjs": "npm:1.26.4"
@@ -2958,7 +2958,7 @@ __metadata:
     "@grafana/ui": "workspace:*"
     "@testing-library/jest-dom": "npm:6.4.2"
     "@testing-library/react": "npm:15.0.2"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
     "@types/react": "npm:18.3.3"
@@ -3364,7 +3364,7 @@ __metadata:
     "@types/d3": "npm:7.4.3"
     "@types/debounce-promise": "npm:3.1.9"
     "@types/eslint": "npm:8.56.12"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/jquery": "npm:3.5.34"
     "@types/lodash": "npm:4.17.4"
     "@types/node": "npm:20.14.2"
@@ -3461,7 +3461,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.5.2"
     "@types/angular": "npm:1.8.9"
     "@types/history": "npm:4.7.11"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/lodash": "npm:4.17.4"
     "@types/react": "npm:18.3.3"
     "@types/react-dom": "npm:18.2.25"
@@ -3660,7 +3660,7 @@ __metadata:
     "@types/d3": "npm:7.4.3"
     "@types/hoist-non-react-statics": "npm:3.3.7"
     "@types/is-hotkey": "npm:0.1.10"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/jquery": "npm:3.5.34"
     "@types/lodash": "npm:4.17.4"
     "@types/mock-raf": "npm:1.0.6"
@@ -8724,13 +8724,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:*, @types/jest@npm:29.5.12, @types/jest@npm:^29.5.4":
-  version: 29.5.12
-  resolution: "@types/jest@npm:29.5.12"
+"@types/jest@npm:*, @types/jest@npm:29.5.14, @types/jest@npm:^29.5.4":
+  version: 29.5.14
+  resolution: "@types/jest@npm:29.5.14"
   dependencies:
     expect: "npm:^29.0.0"
     pretty-format: "npm:^29.0.0"
-  checksum: 10/312e8dcf92cdd5a5847d6426f0940829bca6fe6b5a917248f3d7f7ef5d85c9ce78ef05e47d2bbabc40d41a930e0e36db2d443d2610a9e3db9062da2d5c904211
+  checksum: 10/59ec7a9c4688aae8ee529316c43853468b6034f453d08a2e1064b281af9c81234cec986be796288f1bbb29efe943bc950e70c8fa8faae1e460d50e3cf9760f9b
   languageName: node
   linkType: hard
 
@@ -17141,7 +17141,7 @@ __metadata:
     "@types/google.analytics": "npm:^0.0.46"
     "@types/gtag.js": "npm:^0.0.20"
     "@types/history": "npm:4.7.11"
-    "@types/jest": "npm:29.5.12"
+    "@types/jest": "npm:29.5.14"
     "@types/jquery": "npm:3.5.34"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/jsurl": "npm:^1.2.28"


### PR DESCRIPTION
## Summary

Rebased replacement for stale MintMaker PR #176.

- Bumps `@types/jest` from 29.5.12 → 29.5.14 across 13 `package.json` files
- Updates `yarn.lock` resolution/checksum only (no unrelated dependency downgrades)

The MintMaker branch conflicted with recent `release-1.6` merges (#246–#251) and would have reverted newer `@types/*` pins.

Supersedes #176.

## Test plan

- [ ] Konflux `glo-grafana-globalhub-1-6-on-pull-request` passes

Made with [Cursor](https://cursor.com)