### PR TITLE
chore(deps): update dependency @types/react-transition-group to v4.4.12 (release-1.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@types/react-router-dom": "5.3.3",
     "@types/react-table": "7.7.20",
     "@types/react-test-renderer": "18.3.1",
-    "@types/react-transition-group": "4.4.10",
+    "@types/react-transition-group": "4.4.12",
     "@types/react-virtualized-auto-sizer": "1.0.4",
     "@types/react-window": "1.8.8",
     "@types/react-window-infinite-loader": "^1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -152,7 +152,7 @@
     "@types/react-router-dom": "5.3.3",
     "@types/react-table": "7.7.20",
     "@types/react-test-renderer": "18.3.1",
-    "@types/react-transition-group": "4.4.10",
+    "@types/react-transition-group": "4.4.12",
     "@types/react-window": "1.8.8",
     "@types/slate": "0.47.11",
     "@types/slate-plain-serializer": "0.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3674,7 +3674,7 @@ __metadata:
     "@types/react-router-dom": "npm:5.3.3"
     "@types/react-table": "npm:7.7.20"
     "@types/react-test-renderer": "npm:18.3.1"
-    "@types/react-transition-group": "npm:4.4.10"
+    "@types/react-transition-group": "npm:4.4.12"
     "@types/react-window": "npm:1.8.8"
     "@types/slate": "npm:0.47.11"
     "@types/slate-plain-serializer": "npm:0.7.5"
@@ -9117,12 +9117,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-transition-group@npm:4.4.10, @types/react-transition-group@npm:^4.4.0":
-  version: 4.4.10
-  resolution: "@types/react-transition-group@npm:4.4.10"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10/b429f3bd54d9aea6c0395943ce2dda6b76fb458e902365bd91fd99bf72064fb5d59e2b74e78d10f2871908501d350da63e230d81bda2b616c967cab8dc51bd16
+"@types/react-transition-group@npm:4.4.12, @types/react-transition-group@npm:^4.4.0":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/ea14bc84f529a3887f9954b753843820ac8a3c49fcdfec7840657ecc6a8800aad98afdbe4b973eb96c7252286bde38476fcf64b1c09527354a9a9366e516d9a2
   languageName: node
   linkType: hard
 
@@ -17163,7 +17163,7 @@ __metadata:
     "@types/react-router-dom": "npm:5.3.3"
     "@types/react-table": "npm:7.7.20"
     "@types/react-test-renderer": "npm:18.3.1"
-    "@types/react-transition-group": "npm:4.4.10"
+    "@types/react-transition-group": "npm:4.4.12"
     "@types/react-virtualized-auto-sizer": "npm:1.0.4"
     "@types/react-window": "npm:1.8.8"
     "@types/react-window-infinite-loader": "npm:^1"


### PR DESCRIPTION
## Summary

Rebased replacement for stale MintMaker PR #249.

- Bumps `@types/react-transition-group` from 4.4.10 → 4.4.12 in root and `grafana-ui` `package.json`
- Updates `yarn.lock` resolution/checksum only (no unrelated dependency downgrades)

The MintMaker branch conflicted with recent `release-1.6` merges.

Supersedes #249.

## Test plan

- [ ] Konflux `glo-grafana-globalhub-1-6-on-pull-request` passes

Made with [Cursor](https://cursor.com)