### PR TITLE
ACM-32443: onboard glo-grafana to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 AI assistant context for **glo-grafana** — the Red Hat fork of Grafana used by Multicluster Global Hub for observability dashboards backed by the global hub PostgreSQL database.
 
+Onboarded per [Fleet Engineering Agentic SDLC — repo onboarding](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md). Day-to-day workflow: [ai-dev-workflow.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/ai-dev-workflow.md).
+
 ---
 
 ## Build, Test, and Lint Commands
@@ -59,13 +61,13 @@ Upstream Grafana docs remain in [README.md](README.md) and [docs/](docs/).
 
 ## Personal Config
 
-Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders.
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders. Run `make personalize` in [OpenShift-Fleet/agentic-sdlc](https://github.com/OpenShift-Fleet/agentic-sdlc) to generate it.
 
 ---
 
 ## Fleet Engineering Skills
 
-Fetch and apply the relevant skill when the task matches its domain.
+Use the Fleet plugin in Claude Code (`make install-claude` in agentic-sdlc) when available. In Cursor or other agents without the plugin, fetch and apply the relevant skill URL when the task matches its domain.
 
 | Skill                                                                                                                         | When to use                                                        |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,27 +67,27 @@ Read `.claude/user.local.md` at the start of any task that needs an assignee, em
 
 Fetch and apply the relevant skill when the task matches its domain.
 
-| Skill | When to use |
-|---|---|
-| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Begin work on a Jira ticket — creates sub-task, transitions status |
-| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
-| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | Review a GitHub PR with worktree isolation and inline comments |
-| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
-| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | Triage, search, link, or transition Jira issues |
-| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Create a well-structured bug report with reproduction steps |
-| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | Create a user story with acceptance criteria |
-| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC tickets |
+| Skill                                                                                                                         | When to use                                                        |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md)             | Begin work on a Jira ticket — creates sub-task, transitions status |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md)           | Commit, push, open PR, update Jira                                 |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md)               | Review a GitHub PR with worktree isolation and inline comments     |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md)                     | Fix blocked PRs: merge conflicts, CI failures, review comments     |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md)   | Triage, search, link, or transition Jira issues                    |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md)     | Create a well-structured bug report with reproduction steps        |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | Create a user story with acceptance criteria                       |
+| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC tickets                                |
 
 ---
 
 ## Key Dependencies
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| Go | 1.25.7 | Backend toolchain (see Makefile) |
-| Node / Yarn | (see package.json) | Frontend build |
-| UBI 9 minimal | latest | Runtime base image |
-| openshift-golang-builder | rhel_9_1.25 | Konflux build stage |
+| Dependency               | Version            | Purpose                          |
+| ------------------------ | ------------------ | -------------------------------- |
+| Go                       | 1.25.7             | Backend toolchain (see Makefile) |
+| Node / Yarn              | (see package.json) | Frontend build                   |
+| UBI 9 minimal            | latest             | Runtime base image               |
+| openshift-golang-builder | rhel_9_1.25        | Konflux build stage              |
 
 ---
 
@@ -95,13 +95,13 @@ Fetch and apply the relevant skill when the task matches its domain.
 
 Standard Grafana path variables (set in `Containerfile.konflux`):
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `GF_PATHS_CONFIG` | `/etc/grafana/grafana.ini` | Main config file |
-| `GF_PATHS_DATA` | `/var/lib/grafana` | Data directory |
-| `GF_PATHS_HOME` | `/usr/share/grafana` | Install root |
-| `GF_PATHS_LOGS` | `/var/log/grafana` | Log directory |
-| `GF_PATHS_PLUGINS` | `/var/lib/grafana/plugins` | Plugin directory |
+| Variable                | Default                     | Purpose              |
+| ----------------------- | --------------------------- | -------------------- |
+| `GF_PATHS_CONFIG`       | `/etc/grafana/grafana.ini`  | Main config file     |
+| `GF_PATHS_DATA`         | `/var/lib/grafana`          | Data directory       |
+| `GF_PATHS_HOME`         | `/usr/share/grafana`        | Install root         |
+| `GF_PATHS_LOGS`         | `/var/log/grafana`          | Log directory        |
+| `GF_PATHS_PLUGINS`      | `/var/lib/grafana/plugins`  | Plugin directory     |
 | `GF_PATHS_PROVISIONING` | `/etc/grafana/provisioning` | Provisioning configs |
 
 Container runs as user `grafana` (UID/GID 472). Exposes port **3000**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md — glo-grafana
+
+AI assistant context for **glo-grafana** — the Red Hat fork of Grafana used by Multicluster Global Hub for observability dashboards backed by the global hub PostgreSQL database.
+
+---
+
+## Build, Test, and Lint Commands
+
+```bash
+# Install dependencies
+make deps              # backend + frontend
+make deps-go           # Go modules only
+make deps-js           # yarn frontend only
+
+# Local development build
+make build             # backend + frontend
+make build-go          # Go binaries only
+make build-js          # frontend assets only
+make run-go            # build and run server immediately
+
+# Run Grafana locally (after build)
+./bin/grafana server
+
+# Tests
+make test-go-unit
+make test-js
+make test
+
+# Konflux / production container image
+podman build -f Containerfile.konflux -t glo-grafana:local .
+```
+
+> Konflux builds use `Containerfile.konflux`: applies `stolostron-patches/`, builds with `-build-tags=strictfipsruntime` and CGO enabled for FIPS compliance, publishes multi-arch images via `.tekton/`.
+
+---
+
+## Repo Layout
+
+```text
+Containerfile.konflux     Production multi-stage container build (Konflux / brew)
+stolostron-patches/       ACM-specific patches applied at image build time
+.tekton/                  Konflux PipelineRuns (push + pull-request)
+pkg/                      Grafana backend (services, plugins, APIs)
+public/                   Frontend application
+apps/                     Grafana App SDK apps
+conf/                     Sample grafana.ini and defaults
+packaging/docker/         Container entrypoint (run.sh)
+```
+
+---
+
+## Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for Global Hub integration, auth-proxy header forwarding, datasource configuration, Konflux CI, and deployment context.
+
+Upstream Grafana docs remain in [README.md](README.md) and [docs/](docs/).
+
+---
+
+## Personal Config
+
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders.
+
+---
+
+## Fleet Engineering Skills
+
+Fetch and apply the relevant skill when the task matches its domain.
+
+| Skill | When to use |
+|---|---|
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Begin work on a Jira ticket — creates sub-task, transitions status |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | Review a GitHub PR with worktree isolation and inline comments |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | Triage, search, link, or transition Jira issues |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Create a well-structured bug report with reproduction steps |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | Create a user story with acceptance criteria |
+| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC tickets |
+
+---
+
+## Key Dependencies
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| Go | 1.25.7 | Backend toolchain (see Makefile) |
+| Node / Yarn | (see package.json) | Frontend build |
+| UBI 9 minimal | latest | Runtime base image |
+| openshift-golang-builder | rhel_9_1.25 | Konflux build stage |
+
+---
+
+## Environment Variables
+
+Standard Grafana path variables (set in `Containerfile.konflux`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GF_PATHS_CONFIG` | `/etc/grafana/grafana.ini` | Main config file |
+| `GF_PATHS_DATA` | `/var/lib/grafana` | Data directory |
+| `GF_PATHS_HOME` | `/usr/share/grafana` | Install root |
+| `GF_PATHS_LOGS` | `/var/log/grafana` | Log directory |
+| `GF_PATHS_PLUGINS` | `/var/lib/grafana/plugins` | Plugin directory |
+| `GF_PATHS_PROVISIONING` | `/etc/grafana/provisioning` | Provisioning configs |
+
+Container runs as user `grafana` (UID/GID 472). Exposes port **3000**.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Architecture — glo-grafana (Global Hub)
+
+**glo-grafana** is a Red Hat–maintained fork of upstream Grafana, packaged for Multicluster Global Hub. The Global Hub **operator** deploys this image on the global hub cluster alongside PostgreSQL, Kafka, and the manager. Dashboards query fleet-wide policy compliance and inventory data stored in the global hub database.
+
+Related: [multicluster-global-hub docs/ARCHITECTURE.md](https://github.com/stolostron/multicluster-global-hub/blob/release-5.0/docs/ARCHITECTURE.md) for the full operator/manager/agent data flow.
+
+---
+
+## Role in Global Hub
+
+| Aspect | Detail |
+|---|---|
+| **Deployed by** | `MulticlusterGlobalHub` operator reconciler (`operator/pkg/controllers/grafana`) |
+| **Runs on** | Global hub cluster, namespace `multicluster-global-hub` |
+| **Data source** | PostgreSQL (`multicluster-global-hub-postgresql`) — schemas `local_spec`, `local_status`, `status`, `history` |
+| **Access** | OpenShift OAuth proxy in front of Grafana; auth headers forwarded to datasources |
+| **Image** | `registry.redhat.io/multicluster-globalhub/grafana-rhel9` (prod) / Konflux dev workload quay path |
+
+Grafana is **not** a sync participant — it is a read-only observability UI over data the manager persists.
+
+---
+
+## ACM Customizations
+
+### `stolostron-patches/`
+
+Patches are applied at **image build time** in `Containerfile.konflux` (`git apply ./stolostron-patches/*`).
+
+| Patch | Purpose |
+|---|---|
+| `0001-Forward-headers-from-auth-proxy-to-datasource.patch` | Forwards OpenShift OAuth-proxy authentication headers from the browser session to configured PostgreSQL (and other) datasources, enabling SSO-backed queries without separate Grafana login |
+
+Datasource JSON can list headers to forward via `jsonData.forwardHeaders`.
+
+### FIPS / Konflux build
+
+Production builds use:
+
+```bash
+go run build.go -cgo-enabled -build-tags=strictfipsruntime build
+```
+
+CGO is required for Konflux FIPS binary scanning (`fbc-fips-check-oci-ta`).
+
+---
+
+## Container Image
+
+`Containerfile.konflux` is a two-stage build:
+
+1. **Builder** — `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25`, applies patches, compiles Grafana binaries.
+2. **Runtime** — `registry.access.redhat.com/ubi9/ubi-minimal`, non-root `grafana` user, port 3000, entrypoint `packaging/docker/run.sh`.
+
+Labels identify component `multicluster-globalhub-grafana-rhel9`, CPE `cpe:/a:redhat:multicluster_globalhub:5.0::el9`, version `release-5.0`.
+
+Local build:
+
+```bash
+podman build -f Containerfile.konflux -t glo-grafana:local .
+```
+
+---
+
+## CI/CD (Konflux)
+
+| Pipeline | Trigger | File |
+|---|---|---|
+| Push | `release-5.0` branch push | `.tekton/glo-grafana-globalhub-5-0-push.yaml` |
+| Pull request | PRs to `release-5.0` | `.tekton/glo-grafana-globalhub-5-0-pull-request.yaml` |
+
+- **Application:** `release-globalhub-5-0`
+- **Component:** `glo-grafana-globalhub-5-0`
+- **Output:** `quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-0:<sha>`
+- **Platforms:** linux/x86_64, ppc64le, s390x, arm64
+- **Pipeline:** `konflux-build-catalog/pipelines/common-base.yaml` (hermetic, prefetch gomod)
+
+---
+
+## Branch Strategy
+
+| Branch | Purpose |
+|---|---|
+| `release-5.0` | Current Global Hub 5.0 development and Konflux builds |
+| `release-1.x` | Prior GH release tracks (maintenance / backport source) |
+
+Feature work for the 5.0 line lands on `release-5.0`. Sync branches (e.g. `sync/release-1.8-into-5.0`) merge prior-track fixes forward.
+
+---
+
+## Local Development
+
+Typical workflow for backend-only changes:
+
+```bash
+make deps-go
+make build-go
+./bin/grafana server
+```
+
+Frontend changes require `make deps-js` and `make build-js` (or `make run` for watch mode). Full upstream Grafana contributor docs apply for deep frontend/plugin work.
+
+---
+
+## Testing in Global Hub E2E
+
+The multicluster-global-hub repo runs Grafana-focused E2E via:
+
+```bash
+make e2e-test-grafana
+make e2e-log/grafana
+```
+
+See [acmqe-hoh-e2e](https://github.com/stolostron/acmqe-hoh-e2e) for Polarion-tagged regression suites that exercise dashboard availability post-install.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,13 +8,13 @@ Related: [multicluster-global-hub docs/ARCHITECTURE.md](https://github.com/stolo
 
 ## Role in Global Hub
 
-| Aspect | Detail |
-|---|---|
-| **Deployed by** | `MulticlusterGlobalHub` operator reconciler (`operator/pkg/controllers/grafana`) |
-| **Runs on** | Global hub cluster, namespace `multicluster-global-hub` |
+| Aspect          | Detail                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Deployed by** | `MulticlusterGlobalHub` operator reconciler (`operator/pkg/controllers/grafana`)                              |
+| **Runs on**     | Global hub cluster, namespace `multicluster-global-hub`                                                       |
 | **Data source** | PostgreSQL (`multicluster-global-hub-postgresql`) — schemas `local_spec`, `local_status`, `status`, `history` |
-| **Access** | OpenShift OAuth proxy in front of Grafana; auth headers forwarded to datasources |
-| **Image** | `registry.redhat.io/multicluster-globalhub/grafana-rhel9` (prod) / Konflux dev workload quay path |
+| **Access**      | OpenShift OAuth proxy in front of Grafana; auth headers forwarded to datasources                              |
+| **Image**       | `registry.redhat.io/multicluster-globalhub/grafana-rhel9` (prod) / Konflux dev workload quay path             |
 
 Grafana is **not** a sync participant — it is a read-only observability UI over data the manager persists.
 
@@ -26,8 +26,8 @@ Grafana is **not** a sync participant — it is a read-only observability UI ove
 
 Patches are applied at **image build time** in `Containerfile.konflux` (`git apply ./stolostron-patches/*`).
 
-| Patch | Purpose |
-|---|---|
+| Patch                                                      | Purpose                                                                                                                                                                                     |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `0001-Forward-headers-from-auth-proxy-to-datasource.patch` | Forwards OpenShift OAuth-proxy authentication headers from the browser session to configured PostgreSQL (and other) datasources, enabling SSO-backed queries without separate Grafana login |
 
 Datasource JSON can list headers to forward via `jsonData.forwardHeaders`.
@@ -63,10 +63,10 @@ podman build -f Containerfile.konflux -t glo-grafana:local .
 
 ## CI/CD (Konflux)
 
-| Pipeline | Trigger | File |
-|---|---|---|
-| Push | `release-5.0` branch push | `.tekton/glo-grafana-globalhub-5-0-push.yaml` |
-| Pull request | PRs to `release-5.0` | `.tekton/glo-grafana-globalhub-5-0-pull-request.yaml` |
+| Pipeline     | Trigger                   | File                                                  |
+| ------------ | ------------------------- | ----------------------------------------------------- |
+| Push         | `release-5.0` branch push | `.tekton/glo-grafana-globalhub-5-0-push.yaml`         |
+| Pull request | PRs to `release-5.0`      | `.tekton/glo-grafana-globalhub-5-0-pull-request.yaml` |
 
 - **Application:** `release-globalhub-5-0`
 - **Component:** `glo-grafana-globalhub-5-0`
@@ -78,9 +78,9 @@ podman build -f Containerfile.konflux -t glo-grafana:local .
 
 ## Branch Strategy
 
-| Branch | Purpose |
-|---|---|
-| `release-5.0` | Current Global Hub 5.0 development and Konflux builds |
+| Branch        | Purpose                                                 |
+| ------------- | ------------------------------------------------------- |
+| `release-5.0` | Current Global Hub 5.0 development and Konflux builds   |
 | `release-1.x` | Prior GH release tracks (maintenance / backport source) |
 
 Feature work for the 5.0 line lands on `release-5.0`. Sync branches (e.g. `sync/release-1.8-into-5.0`) merge prior-track fixes forward.


### PR DESCRIPTION
## Summary

Fixes: [ACM-32443](https://redhat.atlassian.net/browse/ACM-32443)

Onboards **glo-grafana** to the Fleet Engineering Agentic SDLC per [repo-onboarding.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md).

- Adds `CLAUDE.md` with verified build/test commands, repo layout, personal config lookup (`make personalize`), and Fleet Engineering skills catalog (URL fallback for Cursor / agents without the plugin)
- Adds `docs/ARCHITECTURE.md` covering Global Hub integration, `stolostron-patches/` (auth-proxy header forwarding), Konflux CI on `release-5.0`, and container build details

## Onboarding checklist

Per [repo-onboarding.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md):

- [x] `CLAUDE.md` — build/lint/test commands verified against `Makefile` and `Containerfile.konflux`
- [x] Personal config lookup with `make personalize` reference
- [x] `docs/ARCHITECTURE.md` created and linked (non-trivial fork + Global Hub integration)
- [x] Fleet Engineering skills URL table (for non-plugin environments)
- [ ] `make personalize` / `make install-claude` — operator setup (outside this PR)
- [ ] First `/start-work` session — post-merge validation

## Context

Companion to [multicluster-global-hub#2512](https://github.com/stolostron/multicluster-global-hub/pull/2512) — documents the **glo-grafana** fork deployed by the Global Hub operator for PostgreSQL-backed observability dashboards.

Day-to-day workflow: [ai-dev-workflow.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/ai-dev-workflow.md).

## Test plan

- [x] Docs-only change — no code or CI target changes
- [x] `CLAUDE.md` repo-layout fence uses `text` language tag (MD040)
- [x] Prettier passes on `CLAUDE.md` and `docs/ARCHITECTURE.md`
- [x] Spot-check `make` targets against root `Makefile` and `Containerfile.konflux`

[ACM-32443]: https://redhat.atlassian.net/browse/ACM-32443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ